### PR TITLE
Fix live-test typecheck for Claude proxy options

### DIFF
--- a/packages/tests/src/ClaudeApi.test.ts
+++ b/packages/tests/src/ClaudeApi.test.ts
@@ -2108,10 +2108,12 @@ async function callClaudeProxyRaw({
   method,
   url,
   body,
+  options,
 }: {
   method: string;
   url: string;
   body?: string;
+  options?: Partial<ClaudeProxyOptions>;
 }): Promise<{ status: number; body: string }> {
   const req = Readable.from(body ? [body] : []) as IncomingMessage;
   req.method = method;
@@ -2119,7 +2121,7 @@ async function callClaudeProxyRaw({
   req.headers = { authorization: "Bearer local-token" };
   const res = new MemoryResponse() as unknown as ServerResponse;
 
-  await handleProxyRequest(req, res, proxyOptions());
+  await handleProxyRequest(req, res, proxyOptions(options));
 
   const memoryRes = res as unknown as MemoryResponse;
   return {


### PR DESCRIPTION
## Summary
- allow `callClaudeProxyRaw` to accept proxy option overrides
- pass those overrides through to `proxyOptions`

## Verification
- `node_modules/.bin/tsc -p packages/tests/tsconfig.json --noEmit`
- `pnpm --filter @togetherlink/tests exec vitest run src/ClaudeApi.test.ts` (47 passed)

Follow-up for the `main` failure in [Live Agent Gauntlet run 30440963077](https://github.com/Nutlope/togetherlink/actions/runs/30440963077).